### PR TITLE
remove trailing commas

### DIFF
--- a/app/Domain/Event/Models/Event.php
+++ b/app/Domain/Event/Models/Event.php
@@ -149,7 +149,7 @@ class Event extends BaseModel implements Reviewable, Searchable
         return new SearchResult(
             $this,
             $this->name,
-            route('events.show-schedule', $this->idSlug()),
+            route('events.show-schedule', $this->idSlug())
             );
     }
 }

--- a/app/Providers/NavigationServiceProvider.php
+++ b/app/Providers/NavigationServiceProvider.php
@@ -26,17 +26,17 @@ class NavigationServiceProvider extends ServiceProvider
                 ->actionIf(
                     optional(auth()->user())->organisesEvents(),
                     [EventsController::class, 'index'],
-                    'Organizing',
+                    'Organizing'
                     )
                 ->actionIf(
                     optional(auth()->user())->speaksAtEvents(),
                     SpeakingAtEventsListController::class,
-                    'Speaking',
+                    'Speaking'
                     )
                 ->actionIf(
                     optional(auth()->user())->attendsEvents(),
                     AttendingEventListController::class,
-                    'Attending',
+                    'Attending'
                     );
         });
 


### PR DESCRIPTION
These trailing commas are causing a syntax error in PHP 7.3
More info => https://laravel-news.com/php-trailing-commas-functions
