### PR TITLE
Remove "$request" from action parameters (Event)

### DIFF
--- a/app/Http/Front/Controllers/EventAdmin/EventsController.php
+++ b/app/Http/Front/Controllers/EventAdmin/EventsController.php
@@ -51,7 +51,7 @@ class EventsController
 
     public function update(Event $event, UpdateEventRequest $request, UpdateEventAction $createEventAction)
     {
-        $event = $createEventAction->execute($event, $request);
+        $event = $createEventAction->execute($event, $request->validated();
 
         flash()->message('The event has been saved!');
 


### PR DESCRIPTION
Consistency?

I guess in your Domain (based on looking other Actions), you do not want to pass Request instance to "execute" methods