### PR TITLE
move country code rule in shared domain

### DIFF
--- a/app/Domain/Shared/Rules/CountryCodeRule.php
+++ b/app/Domain/Shared/Rules/CountryCodeRule.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Domain\User\Rules;
+namespace App\Domain\Shared\Rules;
 
 use Illuminate\Contracts\Validation\Rule;
 use Illuminate\Support\Arr;

--- a/app/Http/Front/Requests/UpdateEventRequest.php
+++ b/app/Http/Front/Requests/UpdateEventRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Front\Requests;
 
-use App\Domain\User\Rules\CountryCodeRule;
+use App\Domain\Shared\Rules\CountryCodeRule;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateEventRequest extends FormRequest

--- a/app/Http/Front/Requests/UpdateUserRequest.php
+++ b/app/Http/Front/Requests/UpdateUserRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Front\Requests;
 
-use App\Domain\User\Rules\CountryCodeRule;
+use App\Domain\Shared\Rules\CountryCodeRule;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 

--- a/resources/views/front/event-admin/events/index.blade.php
+++ b/resources/views/front/event-admin/events/index.blade.php
@@ -16,7 +16,7 @@
                         {{ $event->timespan() }}<br>
                         {{ $event->location }}
                     </div>
-                </>
+                </a>
             @endforeach
         </div>
         {{ $events->links() }}

--- a/tests/Unit/Rules/CountryCodeTest.php
+++ b/tests/Unit/Rules/CountryCodeTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Unit\Rules;
 
-use App\Domain\User\Rules\CountryCodeRule;
+use App\Domain\Shared\Rules\CountryCodeRule;
 use Tests\TestCase;
 
 class CountryCodeTest extends TestCase


### PR DESCRIPTION
moved `CountryCodeRule` to shared domain because its being used with events and user domain also fix minor closing anchor tag issue in admin events `index.blade.php` file